### PR TITLE
Small hack to support env. variables for exploitable's path

### DIFF
--- a/gdb/gdb.go
+++ b/gdb/gdb.go
@@ -369,6 +369,12 @@ func parse(raw []byte, cmd string) crash.Info {
 }
 
 func init() {
+
+	//if env. variable is set, bypass default path for exploitable
+	if os.Getenv("EXPLOITABLE") != "" {
+		gdbBatch[1] = "source " + os.Getenv("EXPLOITABLE") + "/exploitable.py"
+	}
+
 	// build the commandline from the components
 	for _, s := range gdbBatch {
 		gdbArgs = append(gdbArgs, []string{"--ex", s}...)

--- a/gdb/gdb.go
+++ b/gdb/gdb.go
@@ -371,10 +371,16 @@ func parse(raw []byte, cmd string) crash.Info {
 func init() {
 
 	//if env. variable is set, bypass default path for exploitable
-	if os.Getenv("EXPLOITABLE") != "" {
-		gdbBatch[1] = "source " + os.Getenv("EXPLOITABLE") + "/exploitable.py"
+	if os.Getenv("CW_EXPLOITABLE") != "" {
+		explPath := os.Getenv("CW_EXPLOITABLE") + "/exploitable.py"
+		_, err := os.Stat(explPath)
+		if os.IsNotExist(err) {
+			fmt.Println("Invalid exploitable path: ", explPath)
+			os.Exit(1)
+		} else {
+			gdbBatch[1] = "source " + explPath
+		}
 	}
-
 	// build the commandline from the components
 	for _, s := range gdbBatch {
 		gdbArgs = append(gdbArgs, []string{"--ex", s}...)


### PR DESCRIPTION
I was using crashwalk for a project where putting exploitable in ~/src wasn't an option so I wrote a small patch to support the use of env.vars. The code basically checks if the env. var EXPLOITABLE is set, if it's not it switches to the default value. It's a little bit ugly but it can be useful until someone comes up with a better solution.
