### PR TITLE
Fix edge case in dissecting faulting frame

### DIFF
--- a/gdb/gdb.go
+++ b/gdb/gdb.go
@@ -185,13 +185,13 @@ func mustAdvanceTo(token string, scanner *bufio.Scanner, die func()) {
 func parseExploitable(raw []byte, ci *crash.Info, die func()) {
 
 	scanner := bufio.NewScanner(bytes.NewReader(raw))
-
+	// Edge case: "Faulting frame: #  0 None at 0x40008130 in"
 	// Faulting frame: #  4 None at 0x7ffff6fad93b in /usr/lib/x86_64-linux-gnu/libcairo.so.2.11301.0
 	// Faulting frame: #  6 operator new(unsigned long) at 0x7ffff6d87698 in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.20
 	// [  <---ignore--->  ] [  symbol text until "at"  ]     [address]      [ <-- module from here--> ]
 	mustAdvanceTo("Faulting frame:", scanner, die)
 	ff := strings.Fields(scanner.Text())
-	if len(ff) < 9 {
+	if len(ff) < 8 {
 		die()
 	}
 


### PR DESCRIPTION
It is possible for a faulting frame to not describe where it is "in", which causes this function to die.

Ended up being on an exploitable crash which was found in this style of faulting frames;

```
Stack trace:
#  0 None at 0x40008130 in
#  1 None at 0x4b9787 in /state/home/tstrazzere/repo/blahblah/src/shim
#  2 redacted_call at 0x44f7bd in /state/home/tstrazzere/repo/blahblah/src/shim
#  3 _start at 0x409554 in /state/home/tstrazzere/repo/blahblah/src/shim
```