### PR TITLE
Remove check for deprecated target command that required @@

### DIFF
--- a/cmd/cwtriage/main_darwin.go
+++ b/cmd/cwtriage/main_darwin.go
@@ -119,11 +119,6 @@ func main() {
 	}
 
 	command := flag.Args()
-	if len(command) < 2 && !*flagAfl {
-		fmt.Fprintf(os.Stderr, "  FATAL: Minimum target command is: /path/to/target @@\n")
-		flag.Usage()
-		os.Exit(1)
-	}
 
 	runtime.GOMAXPROCS(*flagWorkers)
 

--- a/cmd/cwtriage/main_unix.go
+++ b/cmd/cwtriage/main_unix.go
@@ -120,11 +120,6 @@ func main() {
 	}
 
 	command := flag.Args()
-	if len(command) < 2 && !*flagAfl {
-		fmt.Fprintf(os.Stderr, "  FATAL: Minimum target command is: /path/to/target @@\n")
-		flag.Usage()
-		os.Exit(1)
-	}
 
 	runtime.GOMAXPROCS(*flagWorkers)
 


### PR DESCRIPTION
Currently cwtriage requires the target command to exist of more than just the binary. However if data is read from STDIN this is not necessary any more and the check is obsolete. This PR closes https://github.com/bnagy/crashwalk/issues/26 

If the preferred approach is a -stdin flag let me know and I'll create a new PR. 